### PR TITLE
chore: kubo-prerelease-27-rc1-by-2

### DIFF
--- a/experiments/kubo-prerelease-27-by-2.json
+++ b/experiments/kubo-prerelease-27-by-2.json
@@ -1,0 +1,48 @@
+{
+	"name": "kubo-prerelease-27-rc1-by-2",
+	"max_request_rate": 10,
+	"max_concurrency": 30,
+	"request_filter": "pathonly",
+
+	"defaults": {
+		"instance_type": "io_large"
+	},
+
+	"shared": {
+		"init_commands" : [
+			"ipfs config --json AutoNAT '{\"ServiceMode\": \"disabled\"}'",
+			"ipfs config --json Datastore.BloomFilterSize '268435456'",
+			"ipfs config --json Datastore.StorageGCWatermark 90",
+			"ipfs config --json Datastore.StorageMax '\"160GB\"'",
+			"ipfs config --json Pubsub.StrictSignatureVerification false",
+			"ipfs config --json Reprovider.Interval '\"0\"'",
+			"ipfs config --json Swarm.ConnMgr.GracePeriod '\"2m\"'",
+			"ipfs config --json Swarm.ConnMgr.DisableBandwidthMetrics true",
+			"ipfs config --json Experimental.AcceleratedDHTClient true",
+			"ipfs config --json Experimental.StrategicProviding true"
+		]
+	},
+
+	"targets": [
+		{
+			"name": "kubo26-1",
+			"description": "kubo 0.26.0",
+			"use_image": "ipfs/kubo:v0.26.0"
+		},
+		{
+			"name": "kubo26-2",
+			"description": "kubo 0.26.0",
+			"use_image": "ipfs/kubo:v0.26.0"
+		},
+		{
+			"name": "kubo27-rc1-1",
+			"description": "kubo 0.27.0-rc1",
+			"use_image": "ipfs/kubo:v0.27.0-rc1"
+		},
+		{
+			"name": "kubo27-rc1-2",
+			"description": "kubo 0.27.0-rc1",
+			"use_image": "ipfs/kubo:v0.27.0-rc1"
+		}
+	]
+}


### PR DESCRIPTION
This is the Thunderdome experiment for the prerelease of Kubo 0.27.

- Release issue: https://github.com/ipfs/kubo/issues/10306
- Experiment duration: 1440 minutes (24 hours)
- Dashboards
    - Report: https://probelab.grafana.net/d/03Ot12G4k/experiment-report?orgId=1&refresh=5s&var-experiment=kubo-prerelease-27-rc1-by-2&from=1708423200000&to=1708516800000&var-timeframe=24h
    - Bitswap Report: https://probelab.grafana.net/d/7XdsWwV4k/experiment-report-bitswap?orgId=1&refresh=5s&var-experiment=kubo-prerelease-27-rc1-by-2&orgId=1&from=1708423200000&to=1708516800000&var-timeframe=24h
    - Timeline: https://probelab.grafana.net/d/GE2JD7ZVz/experiment-timeline?orgId=1&var-experiment=kubo-prerelease-27-rc1-by-2&from=1708423200000&to=1708516800000